### PR TITLE
fix: restore the 30s control stream timeout

### DIFF
--- a/src/ControlStream.c
+++ b/src/ControlStream.c
@@ -130,7 +130,11 @@ static PPLT_CRYPTO_CONTEXT decryptionCtx;
 #define IDX_TOGGLE_MOUSE 13
 #define IDX_CLIPBOARD 14
 
-#define CONTROL_STREAM_TIMEOUT_SEC 10
+// 30s, not the upstream 10s: raised by 834baa6 to fix intermittent "Session
+// Initiation" failures where a slow host handshake tripped the timeout. b9c4fe7
+// ("Add mouse toggle") put it back to 10 as collateral -- that commit's subject
+// has nothing to do with timeouts -- which silently undid the fix. Restored.
+#define CONTROL_STREAM_TIMEOUT_SEC 30
 #define CONTROL_STREAM_LINGER_TIMEOUT_SEC 2
 
 static const short packetTypesGen3[] = {


### PR DESCRIPTION
834baa6 ("Patchfor random Session Initiation error") raised CONTROL_STREAM_TIMEOUT_SEC from 10 to 30 because a slow host handshake was intermittently tripping the timeout and failing session initiation.

b9c4fe7 ("Add mouse toggle") set it back to 10. Nothing in that commit's subject or the rest of its diff relates to timeouts -- it adds IDX_TOGGLE_MOUSE, the packet type tables and the ENet ping-scheduling fix -- so this reads as an accidental revert carried in on a stale base, not a decision. The fix has been silently absent ever since.

Restored, with a note recording why it is not the upstream value so the next rebase does not quietly drop it again.